### PR TITLE
Ignoring package-lock.json for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ npm-debug.log
 
 .idea
 .iml
+
+# package-lock.json
+# https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -37,23 +37,23 @@
   "author": "Jack Hsu <jack.hsu@gmail.com> (http://jaysoo.ca/)",
   "license": "ISC",
   "devDependencies": {
-    "appium": "^1.4.16",
-    "babel-core": "^6.4.0",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-react-native": "^1.9.0",
-    "babel-preset-stage-2": "^6.3.13",
-    "chai": "^3.4.1",
-    "chai-as-promised": "^5.2.0",
-    "colors": "^1.1.2",
-    "concurrently": "^2.0.0",
-    "mocha": "^2.3.4",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "sinon": "^1.17.2",
-    "wd": "^0.4.0"
+    "appium": "~1.4.16",
+    "babel-core": "~6.4.0",
+    "babel-preset-es2015": "~6.3.13",
+    "babel-preset-react": "~6.3.13",
+    "babel-preset-react-native": "~1.9.0",
+    "babel-preset-stage-2": "~6.3.13",
+    "chai": "~3.4.1",
+    "chai-as-promised": "~5.2.0",
+    "colors": "~1.1.2",
+    "concurrently": "~2.0.0",
+    "mocha": "~2.3.4",
+    "react": "~15.4.2",
+    "react-addons-test-utils": "~15.4.2",
+    "sinon": "~1.17.2",
+    "wd": "~0.4.0"
   },
   "dependencies": {
-    "react-timer-mixin": "^0.13.3"
+    "react-timer-mixin": "~0.13.3"
   }
 }


### PR DESCRIPTION
Also locking down our versions a little more. [ch4884]

Further (optional) reading:
https://docs.npmjs.com/files/package-lock.json
https://docs.npmjs.com/files/package-locks
npm/npm#17979
npm/npm#18103

TL;DR: There is much community debate about this file.
